### PR TITLE
reference Shoppe::Stripe helper methods rather than settings for stri…

### DIFF
--- a/lib/shoppe/stripe.rb
+++ b/lib/shoppe/stripe.rb
@@ -28,7 +28,7 @@ module Shoppe
         Shoppe::Order.before_confirmation do
           if self.properties['stripe_customer_token']
             begin
-              charge = ::Stripe::Charge.create({:customer => self.properties['stripe_customer_token'], :amount => (self.total * BigDecimal(100)).round, :currency => Shoppe.settings.stripe_currency, :capture => false}, Shoppe.settings.stripe_api_key)
+              charge = ::Stripe::Charge.create({:customer => self.properties['stripe_customer_token'], :amount => (self.total * BigDecimal(100)).round, :currency => Shoppe.settings.stripe_currency, :capture => false}, Shoppe::Stripe.api_key)
               self.payments.create(:amount => self.total, :method => 'Stripe', :reference => charge.id, :refundable => true, :confirmed => false)
             rescue ::Stripe::CardError
               raise Shoppe::Errors::PaymentDeclined, "Payment was declined by the payment processor."

--- a/lib/shoppe/stripe/order_extensions.rb
+++ b/lib/shoppe/stripe/order_extensions.rb
@@ -4,7 +4,7 @@ module Shoppe
       
       def accept_stripe_token(token)
         if token =~ /\Atok/
-          customer = ::Stripe::Customer.create({:description => "Customer for order #{number}", :card => token}, Shoppe.settings.stripe_api_key)
+          customer = ::Stripe::Customer.create({:description => "Customer for order #{number}", :card => token}, Shoppe::Stripe.api_key)
           self.properties['stripe_customer_token'] = customer.id
           self.save
         elsif token =~ /\Acus/ && self.properties[:stripe_customer_token] != token
@@ -20,7 +20,7 @@ module Shoppe
       private
       
       def stripe_customer
-        @stripe_customer ||= ::Stripe::Customer.retrieve(self.properties['stripe_customer_token'], Shoppe.settings.stripe_api_key)
+        @stripe_customer ||= ::Stripe::Customer.retrieve(self.properties['stripe_customer_token'], Shoppe::Stripe.api_key)
       end
       
       def stripe_card

--- a/lib/shoppe/stripe/payment_extensions.rb
+++ b/lib/shoppe/stripe/payment_extensions.rb
@@ -4,7 +4,7 @@ module Shoppe
       
       def stripe_charge
         return false unless self.method == 'Stripe'
-        @stripe_charge ||= ::Stripe::Charge.retrieve(self.reference, Shoppe.settings.stripe_api_key)
+        @stripe_charge ||= ::Stripe::Charge.retrieve(self.reference, Shoppe::Stripe.api_key)
       end
       
       def transaction_url


### PR DESCRIPTION
…pe_api_key and stripe_publishable_key

I wanted to patch stripe_api_key and stripe_publishable_key to read from environment variables rather than from settings stored in the database. This was hard to do because some methods were referencing the settings directly rather than the helper methods that had already been created in Shoppe::Stripe.