### PR TITLE
Adjusted stripe card params name

### DIFF
--- a/vendor/assets/javascripts/shoppe/stripe/form_handler.coffee
+++ b/vendor/assets/javascripts/shoppe/stripe/form_handler.coffee
@@ -5,7 +5,7 @@ $ ->
     
     # Build a hash of params which will be sent to Stripe
     stripeCardParams = {}
-    $.each ['number', 'exp_month', 'exp_year', 'cvc', 'name', 'address_line1', 'address_line2', 'address_city', 'address_state', 'address_zip', 'address_country'], (i,f)->
+    $.each ['number', 'exp-month', 'exp-year', 'cvc', 'name', 'address_line1', 'address_line2', 'address_city', 'address_state', 'address_zip', 'address_country'], (i,f)->
       stripeCardParams[f] = $("[data-stripe='#{f}']").val()
     
     # Send the data to Stripe and define a method to be executed when the response


### PR DESCRIPTION
According to the documentation of Stripe (https://stripe.com/docs/tutorials/forms), the value for the data-stripe attribute of the month and year should be 'exp-month' | 'exp-year' and not 'exp_month' | 'exp_year' (dash instead of underline).